### PR TITLE
fix: Fix getting user and userobj from g object

### DIFF
--- a/ckanext/password_policy/helpers.py
+++ b/ckanext/password_policy/helpers.py
@@ -74,10 +74,10 @@ def custom_password_check(password, username="", fullname=""):
         1 uppercase letter or more
         1 lowercase letter or more
     """
-    if not username and hasattr(g, "user"):
+    if not username and hasattr(g, "user") and g.user:
         username = g.user
 
-    if not fullname and hasattr(g, "userobj"):
+    if not fullname and hasattr(g, "userobj") and g.userobj:
         fullname = g.userobj.fullname
 
     password_length = get_password_length(username)


### PR DESCRIPTION
With the Pylons g object, if we tried to access a missing attribute (e.g. g.user), we were just sent on our way without an error.

With the Flask g object, we have to check that g has the attribute first; if we try to access it and it's not there, we get an error. But even if the g object has the attribute, its value might still be None, causing an error when we try to do something with it. This means we need both checks.