### PR TITLE
fix: Update form input error arguments on perform_reset.html template

### DIFF
--- a/ckanext/password_policy/templates/user/perform_reset.html
+++ b/ckanext/password_policy/templates/user/perform_reset.html
@@ -7,10 +7,10 @@
     {% if user_dict['state'] == 'pending' %}
       <p>{{ _('You can also change username. It can not be modified later.') }}</p>
       {{ form.input("name", id="field-name", label=_("Username"), type="text", value=user_dict["name"],
-         error=errors.name, attrs={'autocomplete': 'no', 'class': 'form-control control-medium'}, classes=["form-group"]) }}
+         error='', attrs={'autocomplete': 'no', 'class': 'form-control control-medium'}, classes=["form-group"]) }}
     {% endif %}
-    {{ form.input("password1", id="field-password", label=_("Password"), type="password", value='', error=errors.password1, attrs={'autocomplete': 'no', 'class': 'form-control control-medium'}, classes=["form-group"]) }}
-    {{ form.input("password2", id="field-confirm-password", label=_("Confirm"), type="password", value='', error=errors.password2, attrs={'autocomplete': 'no', 'class': 'form-control control-medium'}, classes=["form-group"]) }}
+    {{ form.input("password1", id="field-password", label=_("Password"), type="password", value='', error='', attrs={'autocomplete': 'no', 'class': 'form-control control-medium'}, classes=["form-group"]) }}
+    {{ form.input("password2", id="field-confirm-password", label=_("Confirm"), type="password", value='', error='', attrs={'autocomplete': 'no', 'class': 'form-control control-medium'}, classes=["form-group"]) }}
     <div class="info-block ">
       <i class="fa fa-info-circle"></i>
       {{ h.requirements_message(username=user_dict["name"]) }}


### PR DESCRIPTION
This fixes an error when the user clicks the password-reset link.